### PR TITLE
Checkbox component

### DIFF
--- a/react/src/components/stencil-generated/index.ts
+++ b/react/src/components/stencil-generated/index.ts
@@ -8,4 +8,5 @@ import type { JSX } from '@dsa-ui/wc';
 import { defineCustomElements } from '@dsa-ui/wc/loader';
 
 defineCustomElements();
+export const DsaCheckbox = /*@__PURE__*/createReactComponent<JSX.DsaCheckbox, HTMLDsaCheckboxElement>('dsa-checkbox');
 export const MyComponent = /*@__PURE__*/createReactComponent<JSX.MyComponent, HTMLMyComponentElement>('my-component');

--- a/wc/custom-elements.json
+++ b/wc/custom-elements.json
@@ -118,6 +118,186 @@
           }
         }
       ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/forms/dsa-checkbox/dsa-checkbox.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Checkbox control. Light children will be used for the label.",
+          "name": "DsaCheckbox",
+          "members": [
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Whether the command or control is checked.\nNote: this behaves the way it does in React, not the way it does in HTML."
+            },
+            {
+              "kind": "field",
+              "name": "defaultChecked",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Whether the checkbox is checked by default."
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the form control is disabled"
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "description": "Name of the form control. Submitted with the form as part of a name/value pair"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "description": "The value that will be submitted when the checkbox is checked"
+            },
+            {
+              "kind": "field",
+              "name": "el",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "description": "Host element."
+            },
+            {
+              "kind": "method",
+              "name": "watchHandler",
+              "privacy": "protected"
+            },
+            {
+              "kind": "field",
+              "name": "_form",
+              "type": {
+                "text": "HTMLFormElement | undefined"
+              },
+              "privacy": "private",
+              "description": "Owner form."
+            },
+            {
+              "kind": "field",
+              "name": "_input",
+              "type": {
+                "text": "HTMLInputElement"
+              },
+              "privacy": "private",
+              "description": "Wrapped <input> element."
+            },
+            {
+              "kind": "field",
+              "name": "_onChangeInput",
+              "privacy": "private",
+              "description": "Handle onChange event on <input>"
+            },
+            {
+              "kind": "field",
+              "name": "_handleFormData",
+              "privacy": "private",
+              "description": "Participate in FormData."
+            },
+            {
+              "kind": "method",
+              "name": "_findContainingForm",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "HTMLFormElement | undefined"
+                }
+              },
+              "description": "Find the form owning this control."
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "checked",
+              "fieldName": "checked",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "name": "default-checked",
+              "fieldName": "defaultChecked",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "name": "disabled",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "name",
+              "fieldName": "name",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "value",
+              "fieldName": "value",
+              "type": {
+                "text": "string"
+              }
+            }
+          ],
+          "tagName": "dsa-checkbox",
+          "events": [
+            {
+              "name": "_change",
+              "type": {
+                "text": "EventEmitter<unknown>"
+              }
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "DsaCheckbox",
+          "declaration": {
+            "name": "DsaCheckbox",
+            "module": "src/components/forms/dsa-checkbox/dsa-checkbox.tsx"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "dsa-checkbox",
+          "declaration": {
+            "name": "DsaCheckbox",
+            "module": "src/components/forms/dsa-checkbox/dsa-checkbox.tsx"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/forms/dsa-checkbox/test/dsa-checkbox.spec.tsx",
+      "declarations": [],
+      "exports": []
     }
   ]
 }

--- a/wc/src/components.d.ts
+++ b/wc/src/components.d.ts
@@ -6,12 +6,6 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
-    /**
-      * Checkbox control. Light children will be used for the label.
-      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
-      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
-      * @see {@link HTMLInputElement HTMLInputElement interface}
-     */
     interface DsaCheckbox {
         /**
           * Whether the command or control is checked. Note: this behaves the way it does in React, not the way it does in HTML.
@@ -62,20 +56,8 @@ export interface DsaCheckboxCustomEvent<T> extends CustomEvent<T> {
     target: HTMLDsaCheckboxElement;
 }
 declare global {
-    /**
-      * Checkbox control. Light children will be used for the label.
-      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
-      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
-      * @see {@link HTMLInputElement HTMLInputElement interface}
-     */
     interface HTMLDsaCheckboxElement extends Components.DsaCheckbox, HTMLStencilElement {
     }
-    /**
-      * Checkbox control. Light children will be used for the label.
-      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
-      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
-      * @see {@link HTMLInputElement HTMLInputElement interface}
-     */
     var HTMLDsaCheckboxElement: {
         prototype: HTMLDsaCheckboxElement;
         new (): HTMLDsaCheckboxElement;
@@ -92,13 +74,7 @@ declare global {
     }
 }
 declare namespace LocalJSX {
-    /**
-    * Checkbox control. Light children will be used for the label.
-    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
-    * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
-    * @see {@link HTMLInputElement HTMLInputElement interface}
-   */
-  interface DsaCheckbox {
+    interface DsaCheckbox {
         /**
           * Whether the command or control is checked. Note: this behaves the way it does in React, not the way it does in HTML.
          */

--- a/wc/src/components.d.ts
+++ b/wc/src/components.d.ts
@@ -6,6 +6,38 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
+    /**
+      * Checkbox control. Light children will be used for the label.
+      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
+      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
+      * @see {@link HTMLInputElement HTMLInputElement interface}
+     */
+    interface DsaCheckbox {
+        /**
+          * Whether the command or control is checked. Note: this behaves the way it does in React, not the way it does in HTML.
+         */
+        "checked": boolean;
+        /**
+          * Whether the checkbox is checked by default.
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#checked MDN docs}
+         */
+        "defaultChecked": boolean;
+        /**
+          * Whether the form control is disabled
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#disabled MDN docs}
+         */
+        "disabled": boolean;
+        /**
+          * Name of the form control. Submitted with the form as part of a name/value pair
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name MDN docs}
+         */
+        "name": string;
+        /**
+          * The value that will be submitted when the checkbox is checked
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value MDN docs}
+         */
+        "value": string;
+    }
     interface MyComponent {
         /**
           * The first name
@@ -25,7 +57,29 @@ export namespace Components {
         "styling": string;
     }
 }
+export interface DsaCheckboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLDsaCheckboxElement;
+}
 declare global {
+    /**
+      * Checkbox control. Light children will be used for the label.
+      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
+      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
+      * @see {@link HTMLInputElement HTMLInputElement interface}
+     */
+    interface HTMLDsaCheckboxElement extends Components.DsaCheckbox, HTMLStencilElement {
+    }
+    /**
+      * Checkbox control. Light children will be used for the label.
+      * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
+      * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
+      * @see {@link HTMLInputElement HTMLInputElement interface}
+     */
+    var HTMLDsaCheckboxElement: {
+        prototype: HTMLDsaCheckboxElement;
+        new (): HTMLDsaCheckboxElement;
+    };
     interface HTMLMyComponentElement extends Components.MyComponent, HTMLStencilElement {
     }
     var HTMLMyComponentElement: {
@@ -33,10 +87,44 @@ declare global {
         new (): HTMLMyComponentElement;
     };
     interface HTMLElementTagNameMap {
+        "dsa-checkbox": HTMLDsaCheckboxElement;
         "my-component": HTMLMyComponentElement;
     }
 }
 declare namespace LocalJSX {
+    /**
+    * Checkbox control. Light children will be used for the label.
+    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
+    * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
+    * @see {@link HTMLInputElement HTMLInputElement interface}
+   */
+  interface DsaCheckbox {
+        /**
+          * Whether the command or control is checked. Note: this behaves the way it does in React, not the way it does in HTML.
+         */
+        "checked"?: boolean;
+        /**
+          * Whether the checkbox is checked by default.
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#checked MDN docs}
+         */
+        "defaultChecked"?: boolean;
+        /**
+          * Whether the form control is disabled
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#disabled MDN docs}
+         */
+        "disabled"?: boolean;
+        /**
+          * Name of the form control. Submitted with the form as part of a name/value pair
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name MDN docs}
+         */
+        "name"?: string;
+        "on_change"?: (event: DsaCheckboxCustomEvent<unknown>) => void;
+        /**
+          * The value that will be submitted when the checkbox is checked
+          * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value MDN docs}
+         */
+        "value"?: string;
+    }
     interface MyComponent {
         /**
           * The first name
@@ -56,6 +144,7 @@ declare namespace LocalJSX {
         "styling"?: string;
     }
     interface IntrinsicElements {
+        "dsa-checkbox": DsaCheckbox;
         "my-component": MyComponent;
     }
 }
@@ -63,6 +152,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "dsa-checkbox": LocalJSX.DsaCheckbox & JSXBase.HTMLAttributes<HTMLDsaCheckboxElement>;
             "my-component": LocalJSX.MyComponent & JSXBase.HTMLAttributes<HTMLMyComponentElement>;
         }
     }

--- a/wc/src/components/forms/dsa-checkbox/dsa-checkbox.css
+++ b/wc/src/components/forms/dsa-checkbox/dsa-checkbox.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/wc/src/components/forms/dsa-checkbox/dsa-checkbox.css
+++ b/wc/src/components/forms/dsa-checkbox/dsa-checkbox.css
@@ -1,3 +1,9 @@
+@tailwind base;
+
 :host {
   display: block;
+}
+
+:host input {
+  @apply accent-red;
 }

--- a/wc/src/components/forms/dsa-checkbox/dsa-checkbox.tsx
+++ b/wc/src/components/forms/dsa-checkbox/dsa-checkbox.tsx
@@ -1,0 +1,139 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  Watch,
+} from '@stencil/core';
+
+import {JSXBase} from '@stencil/core/internal';
+
+/**
+ * Checkbox control. Light children will be used for the label.
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox | MDN docs}
+ * @see {@link JSXBase.InputHTMLAttributes `<input>` attributes}
+ * @see {@link HTMLInputElement HTMLInputElement interface}
+ */
+@Component({
+  tag: 'dsa-checkbox',
+  styleUrl: 'dsa-checkbox.css',
+  shadow: true,
+})
+export class DsaCheckbox {
+  constructor() {
+    this.checked = this.defaultChecked;
+  }
+
+  /**
+   * Whether the command or control is checked.
+   * Note: this behaves the way it does in React, not the way it does in HTML.
+   */
+  @Prop({mutable: true}) checked: boolean;
+
+  /**
+   * Whether the checkbox is checked by default.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#checked MDN docs}
+   */
+  @Prop({reflect: true}) defaultChecked: boolean;
+
+  /**
+   * Whether the form control is disabled
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#disabled MDN docs}
+   */
+  @Prop({reflect: true}) disabled = false;
+
+  /**
+   * Name of the form control. Submitted with the form as part of a name/value pair
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#name MDN docs}
+   */
+  @Prop({reflect: true}) name: string;
+
+  /**
+   * The value that will be submitted when the checkbox is checked
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#value MDN docs}
+   */
+  @Prop({reflect: true}) value: string;
+
+  /** Host element. */
+  @Element() el: HTMLElement;
+
+  @Event({
+    eventName: "_change"
+  }) _change: EventEmitter<unknown>;
+
+  @Watch('checked')
+  protected watchHandler() {
+    this._input.checked = this.checked;
+    this._change.emit()
+  }
+
+  connectedCallback() {
+    // connect to FormData
+    this._form = this._findContainingForm();
+    if (this._form) {
+      this._form.addEventListener('formdata', this._handleFormData);
+    }
+  }
+
+  disconnectedCallback() {
+    // disconnect from FormData
+    if (this._form) {
+      this._form.removeEventListener('formdata', this._handleFormData);
+      this._form = null;
+    }
+  }
+
+  /** Owner form. */
+  private _form?: HTMLFormElement;
+
+  /** Wrapped <input> element. */
+  private _input: HTMLInputElement;
+
+  /** Handle onChange event on <input> */
+  private _onChangeInput = (): void => {
+    this.checked = this._input.checked;
+  };
+
+  /** Participate in FormData. */
+  private _handleFormData = (e: FormDataEvent): void => {
+    if (!this.disabled && this.checked) {
+      e.formData.append(this.name, this.value ?? 'on');
+    }
+  };
+
+  /** Find the form owning this control. */
+  private _findContainingForm(): HTMLFormElement | undefined {
+    // can only be in a form in the same "scope", ShadowRoot or Document
+    const root = this.el.getRootNode() as ShadowRoot | Document;
+
+    const forms = Array.from(root.querySelectorAll('form'));
+    // we can only be in one <form>, so the first one to contain us is the correct one
+    return forms.find(form => form.contains(this.el));
+  }
+
+  render() {
+    const mirroredAttributeNames: (keyof JSXBase.InputHTMLAttributes<HTMLInputElement>)[] =
+      ['disabled', 'value'];
+    const mirroredAttrs = Object.fromEntries(
+      mirroredAttributeNames.map(a => [a, this[a]]),
+    );
+
+    return (
+      <Host>
+        <label>
+          <input
+            checked={this.defaultChecked}
+            onChange={this._onChangeInput}
+            ref={ref => (this._input = ref)}
+            type="checkbox"
+            {...mirroredAttrs}
+          />{' '}
+          <slot />
+        </label>
+      </Host>
+    );
+  }
+}

--- a/wc/src/components/forms/dsa-checkbox/dsa-checkbox.tsx
+++ b/wc/src/components/forms/dsa-checkbox/dsa-checkbox.tsx
@@ -60,9 +60,7 @@ export class DsaCheckbox {
   /** Host element. */
   @Element() el: HTMLElement;
 
-  @Event({
-    eventName: "_change"
-  }) _change: EventEmitter<unknown>;
+  @Event() _change: EventEmitter<unknown>;
 
   @Watch('checked')
   protected watchHandler() {

--- a/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.e2e.ts
+++ b/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.e2e.ts
@@ -1,0 +1,28 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('dsa-checkbox', () => {
+  it('participates in FormData', async () => {
+    const page = await newE2EPage();
+
+    await page.setContent(`
+      <form>
+        <dsa-checkbox checked name="apple">Apple</dsa-checkbox>
+        <dsa-checkbox checked name="banana" value="agree">Banana</dsa-checkbox>
+        <dsa-checkbox name="cherry">Cherry</dsa-checkbox>
+        <dsa-checkbox checked disabled name="durian">Durian</dsa-checkbox>
+      </form>`);
+
+    const data = await page.$eval('form', form => {
+      const json: any = {};
+      new FormData(form).forEach((value, key) => {
+        json[key] = value;
+      });
+      return json;
+    });
+
+    expect(data).toEqual({
+      apple: 'on',
+      banana: 'agree',
+    });
+  });
+});

--- a/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.spec.tsx
+++ b/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.spec.tsx
@@ -1,0 +1,55 @@
+import {newSpecPage, SpecPage} from '@stencil/core/testing';
+import {DsaCheckbox} from '../dsa-checkbox';
+
+describe('dsa-checkbox', () => {
+  let page: SpecPage;
+
+  beforeEach(async () => {
+    page = await newSpecPage({
+      components: [DsaCheckbox],
+      html: `<dsa-checkbox>Remember me</dsa-checkbox>`,
+    });
+  });
+
+  it('syncs checked property with its <input> element', async () => {
+    const component = page.body.querySelector('dsa-checkbox');
+    const input = component.shadowRoot.querySelector('input');
+
+    // component -> input
+    for (const value of [true, false]) {
+      component.checked = value;
+      await page.waitForChanges();
+      expect(input.checked).toBe(value);
+    }
+
+    // input -> component
+    for (const _ of [true, false]) {
+      // setting input.checked doesn't fire change
+      input.click();
+      await page.waitForChanges();
+      expect(component.checked).toBe(input.checked);
+    }
+  });
+
+  it('syncs disabled property with its <input> element', async () => {
+    const component = page.body.querySelector("dsa-checkbox");
+    const input = component.shadowRoot.querySelector('input');
+
+    // component -> input
+    for (const value of [true, false]) {
+      component.disabled = value;
+      await page.waitForChanges();
+      expect(input.disabled).toBe(value);
+    }
+  });
+
+  it("fires onchange event", async () => {
+    const component = page.body.querySelector('dsa-checkbox');
+
+    const fn = jest.fn();
+    component.addEventListener("change", fn);
+
+    component.checked = !component.checked;
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.spec.tsx
+++ b/wc/src/components/forms/dsa-checkbox/test/dsa-checkbox.spec.tsx
@@ -47,7 +47,7 @@ describe('dsa-checkbox', () => {
     const component = page.body.querySelector('dsa-checkbox');
 
     const fn = jest.fn();
-    component.addEventListener("change", fn);
+    component.addEventListener("_change", fn);
 
     component.checked = !component.checked;
     expect(fn).toHaveBeenCalledTimes(1);

--- a/wc/stories/forms/dsa-checkbox.stories.ts
+++ b/wc/stories/forms/dsa-checkbox.stories.ts
@@ -1,0 +1,31 @@
+import { Meta, StoryFn } from '@storybook/web-components';
+import { formatArgs, omit } from '../utils/utils';
+
+type Component = HTMLElementTagNameMap['dsa-checkbox'] & {
+  innerHTML: string;
+};
+
+export default {
+  title: 'Forms/Checkbox',
+  component: 'dsa-checkbox',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/1Hty7YjMHXRHPwbESKUBf1/mydsa-public-01?node-id=174%3A10036',
+    },
+  },
+} as Meta<Component>;
+
+const Template: StoryFn<Component> = args =>
+  `<dsa-checkbox ${formatArgs(omit(args, ['innerHTML']))}>${
+    args.innerHTML
+  }</dsa-checkbox>`;
+
+export const Default: StoryFn<Component> = Template.bind({});
+Default.storyName = 'Checkbox';
+Default.args = {
+  defaultChecked: true,
+  innerHTML:
+    'I agree to the <a href="#" onclick="return false;">terms and conditions</a>',
+  name: 'agree',
+};


### PR DESCRIPTION
This implements `dsa-checkbox` component, which resolves #33. Draft PR since I have some questions:

- in React, I often do
```tsx
export function Checkbox(props: Omit<
  React.InputHTMLAttributes<HTMLInputElement>,
  "id" | "type",
>) {
  const {children, ...attrs} = props;
  const id = useId();
  
  return (
    <>
      <input id={id} type="checkbox" {...attrs} />
      <label htmlFor={id}>{children}</label>
    </>
  );
}
```
to extend native components. This way, all attributes on `<Checkbox>` get passed to the underlying `<input>`. Is this possible to do with Web Components / what is the idiom here?
- what sort of tests should I write for this?

Also note this component does almost nothing, since we don't have detailed designs for it yet.